### PR TITLE
Gym feature updates

### DIFF
--- a/app/Http/Controllers/Api/GymController.php
+++ b/app/Http/Controllers/Api/GymController.php
@@ -206,4 +206,177 @@ class GymController extends Controller
         return $this->gymServices->list_programs_exercises($request);
     }
 
+    /**
+     * Add client exercise (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function add_client_exercise(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $program_id = $request['client_program_id'];
+
+        $validationResult = $this->gymServices->validateClientProgram($program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->add_client_exercise($request);
+    }
+
+    /**
+     * Edit client exercise (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function edit_client_exercise(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $exercise_id = $request['client_exercise_id'];
+
+        $validationResult = $this->gymServices->validateClientExercise($exercise_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->update_client_exercise($request);
+    }
+
+    /**
+     * Delete client exercise (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete_client_exercise(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $exercise_id = $request['client_exercise_id'];
+
+        $validationResult = $this->gymServices->validateClientExercise($exercise_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->delete_client_exercise($request);
+    }
+
+    /**
+     * Copy client exercise (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function copy_client_exercise(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $exercise_id = $request['client_exercise_id'];
+        $to_program_id = $request['to_client_program_id'];
+
+        // Validate both the source exercise and destination program
+        $validationResult = $this->gymServices->validateClientExercise($exercise_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        $validationResult = $this->gymServices->validateClientProgram($to_program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->copy_client_exercise($request);
+    }
+
+    /**
+     * Copy client exercise days (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function copy_client_exercise_days(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $from_program_id = $request['from_client_program_id'];
+        $to_program_id = $request['to_client_program_id'];
+
+        // Validate both programs
+        $validationResult = $this->gymServices->validateClientProgram($from_program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        $validationResult = $this->gymServices->validateClientProgram($to_program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->copy_client_exercise_days($request);
+    }
+
+    /**
+     * Cut client exercise days (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function cut_client_exercise_days(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $from_program_id = $request['from_client_program_id'];
+        $to_program_id = $request['to_client_program_id'];
+
+        // Validate both programs
+        $validationResult = $this->gymServices->validateClientProgram($from_program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        $validationResult = $this->gymServices->validateClientProgram($to_program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->cut_client_exercise_days($request);
+    }
+
+    /**
+     * Delete client exercise days (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete_client_exercise_days(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $program_id = $request['client_program_id'];
+
+        $validationResult = $this->gymServices->validateClientProgram($program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->delete_client_exercise_days($request);
+    }
+
+    /**
+     * Delete client program (gym admin/owner only)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete_client_program(Request $request)
+    {
+        $admin_gym_id = $request->user()->gym_coach->gym_id;
+        $program_id = $request['client_program_id'];
+
+        $validationResult = $this->gymServices->validateClientProgram($program_id, $admin_gym_id);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        return $this->gymServices->delete_client_program($request);
+    }
+
 }

--- a/app/Http/Controllers/Api/GymController.php
+++ b/app/Http/Controllers/Api/GymController.php
@@ -379,4 +379,169 @@ class GymController extends Controller
         return $this->gymServices->delete_client_program($request);
     }
 
+    /**
+     * List gym programs (similar to ProgramController::index())
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function list_gym_programs(Request $request)
+    {
+        return $this->gymServices->list_gym_programs($request);
+    }
+
+    /**
+     * Add gym program
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function add_gym_program(Request $request)
+    {
+        return $this->gymServices->add_gym_program($request);
+    }
+
+    /**
+     * Update gym program
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function update_gym_program(Request $request)
+    {
+        return $this->gymServices->update_gym_program($request);
+    }
+
+    /**
+     * Delete gym program
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete_gym_program(Request $request)
+    {
+        return $this->gymServices->delete_gym_program($request);
+    }
+
+    /**
+     * Update gym program sync
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function update_gym_program_sync(Request $request)
+    {
+        return $this->gymServices->update_gym_program_sync($request);
+    }
+
+    /**
+     * List gym program days
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function list_gym_program_days(Request $request)
+    {
+        return $this->gymServices->list_gym_program_days($request);
+    }
+
+    /**
+     * List gym program exercises
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function list_gym_program_exercises(Request $request)
+    {
+        return $this->gymServices->list_gym_program_exercises($request);
+    }
+
+    /**
+     * List gym program exercises by day
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function list_gym_program_exercises_by_day(Request $request)
+    {
+        return $this->gymServices->list_gym_program_exercises_by_day($request);
+    }
+
+    /**
+     * Add gym program exercise
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function add_gym_program_exercise(Request $request)
+    {
+        return $this->gymServices->add_gym_program_exercise($request);
+    }
+
+    /**
+     * Update gym program exercise
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function update_gym_program_exercise(Request $request)
+    {
+        return $this->gymServices->update_gym_program_exercise($request);
+    }
+
+    /**
+     * Delete gym program exercise
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete_gym_program_exercise(Request $request)
+    {
+        return $this->gymServices->delete_gym_program_exercise($request);
+    }
+
+    /**
+     * Copy gym program exercise
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function copy_gym_program_exercise(Request $request)
+    {
+        return $this->gymServices->copy_gym_program_exercise($request);
+    }
+
+    /**
+     * Copy gym program exercise days
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function copy_gym_program_exercise_days(Request $request)
+    {
+        return $this->gymServices->copy_gym_program_exercise_days($request);
+    }
+
+    /**
+     * Cut gym program exercise days
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function cut_gym_program_exercise_days(Request $request)
+    {
+        return $this->gymServices->cut_gym_program_exercise_days($request);
+    }
+
+    /**
+     * Delete gym program exercise days
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete_gym_program_exercise_days(Request $request)
+    {
+        return $this->gymServices->delete_gym_program_exercise_days($request);
+    }
+
 }

--- a/app/Http/Controllers/Api/ProgramController.php
+++ b/app/Http/Controllers/Api/ProgramController.php
@@ -18,7 +18,7 @@ class ProgramController extends Controller
      */
     public function index(Request $request)
     {
-        return $this->programServices->index($request);
+        return $this->programServices->index($request, $request->user()->id);
     }
 
     /**

--- a/app/Services/DatabaseServices/DB_Coach_Gyms.php
+++ b/app/Services/DatabaseServices/DB_Coach_Gyms.php
@@ -55,6 +55,12 @@ class DB_Coach_Gyms
             ->where(['coach_id' => $coach_id, 'gym_id' => $gym_id])
             ->first();
     }
+    public function gym_coach_exists(mixed $gym_id, mixed $coach_id)
+    {
+        return GymCoach::query()
+            ->where(['coach_id' => $coach_id, 'gym_id' => $gym_id])
+            ->exists();
+    }
 
     public function delete_gym_coach($gym_coach)
     {

--- a/app/Services/DatabaseServices/DB_Exercises.php
+++ b/app/Services/DatabaseServices/DB_Exercises.php
@@ -99,4 +99,15 @@ class DB_Exercises
         return ProgramExercise::query()->where('id', $id)->exists();
     }
 
+    /**
+     * Get only the program_id for an exercise (lightweight query for validation)
+     *
+     * @param mixed $exercise_id
+     * @return mixed
+     */
+    public function get_exercise_program_id(mixed $exercise_id)
+    {
+        return ProgramExercise::where('id', $exercise_id)->value('program_id');
+    }
+
 }

--- a/app/Services/DatabaseServices/DB_Programs.php
+++ b/app/Services/DatabaseServices/DB_Programs.php
@@ -84,4 +84,15 @@ class DB_Programs
             ])
             ->exists();
     }
+
+    /**
+     * Get only the coach_id for a program (lightweight query for validation)
+     *
+     * @param mixed $program_id
+     * @return mixed
+     */
+    public function get_program_coach_id(mixed $program_id)
+    {
+        return Program::where('id', $program_id)->value('coach_id');
+    }
 }

--- a/app/Services/GymServices.php
+++ b/app/Services/GymServices.php
@@ -246,7 +246,7 @@ class GymServices
                 "id" => strval($join_request->id),
                 "gym_name" => $join_request->gym->name,
                 "gym_admin_email" => $join_request->admin ? $join_request->admin->email : "",
-                "coach_email" => $join_request->coach->email,
+                "coach_email" => $join_request->email,
                 "request_date" => Carbon::parse($join_request->created_at)->toDateString(),
                 "request_time" => Carbon::parse($join_request->created_at)->toTimeString(),
                 "request_type" => $send_type,
@@ -548,7 +548,6 @@ class GymServices
         if ($validationResult !== true) {
             return $validationResult;
         }
-
         return $this->oneToOneProgramServices->index($request);
     }
 
@@ -556,14 +555,16 @@ class GymServices
      * Validate if the client coach belongs to the admins gym and
      * if the admin has the privilege to access the coach's clients.
      *
-     * @param int $client_id
+     * @param int|null $client_id
      * @param string $admin_gym_privilege
      * @param int $admin_gym_id
      * @return JsonResponse|true True if validation passes, or an error response if not.
      */
-    public function validateClientCoach(int $client_id, string $admin_gym_privilege, int $admin_gym_id): bool|JsonResponse
+    public function validateClientCoach(int|null $client_id, string $admin_gym_privilege, int $admin_gym_id): bool|JsonResponse
     {
-
+        if (!$client_id) {
+            return sendError("Client not found", 404);
+        }
 
         // Find the coach ID associated with the client.
         $coach_id = $this->DB_Clients->find_coach_id($client_id)->coach_id;

--- a/app/Services/GymServices.php
+++ b/app/Services/GymServices.php
@@ -820,17 +820,6 @@ class GymServices
     }
 
     /**
-     * Add gym program (for requesting admin/owner)
-     *
-     * @param $request
-     * @return JsonResponse
-     */
-    public function add_gym_program($request)
-    {
-        return $this->programServices->store($request);
-    }
-
-    /**
      * Update gym program
      *
      * @param $request

--- a/app/Services/ProgramServices.php
+++ b/app/Services/ProgramServices.php
@@ -30,10 +30,13 @@ class ProgramServices
     {
     }
 
-    public function index($request)
+    public function index($request, $coach_id = null)
     {
         $this->validationServices->list_programs($request);
-        $coach_id = $request->user()->id;
+        // If coach_id is not provided, use the authenticated user's ID (backward compatibility)
+        if ($coach_id === null) {
+            $coach_id = $request->user()->id;
+        }
         $search = $request['search'];
         $programs = $this->DB_Programs->get_programs_with_coach($coach_id, $search);
         $programs_arr = $this->program_info_arr($programs);

--- a/app/Services/ValidationServices.php
+++ b/app/Services/ValidationServices.php
@@ -53,7 +53,7 @@ class ValidationServices
             'name' => 'required|max:50',
             'description' => 'required|max:1000',
             'type' => 'required|in:0,1,2,3',
-            'starting_date' => 'required_if:type,1|date|date_format:Y-m-d',
+            'starting_date' => 'nullable|required_if:type,1|date|date_format:Y-m-d',
             'sync' => 'required_if:type,1|required_if:type,3|in:0,1',
             'image' => 'nullable'
         ]);
@@ -66,7 +66,7 @@ class ValidationServices
             'name' => 'required|max:50',
             'description' => 'required|max:1000',
             'type' => 'required|in:0,1,2,3',
-            'starting_date' => 'required_if:type,1|date|date_format:Y-m-d',
+            'starting_date' => 'nullable|required_if:type,1|date|date_format:Y-m-d',
             'image' => 'nullable'
         ]);
     }

--- a/routes/gym.php
+++ b/routes/gym.php
@@ -54,7 +54,6 @@ Route::middleware(['auth:api', 'CheckSubscription', 'CheckCoachUser'])->group(fu
 
         // Template Program management
         Route::post('gym/programs/list', [GymController::class, 'list_gym_programs']);
-        Route::post('gym/program/add', [GymController::class, 'add_gym_program']);
         Route::post('gym/program/edit', [GymController::class, 'update_gym_program']);
         Route::post('gym/program/delete', [GymController::class, 'delete_gym_program']);
         Route::post('gym/program/update/sync', [GymController::class, 'update_gym_program_sync']);

--- a/routes/gym.php
+++ b/routes/gym.php
@@ -40,6 +40,17 @@ Route::middleware(['auth:api', 'CheckSubscription', 'CheckCoachUser'])->group(fu
         Route::post('gym/client/program/exercises/list', [GymController::class, 'list_programs_exercises']);
         Route::post('gym/client/program/exercises/by/date/list', [GymController::class, 'list_client_program_exercises_by_date']);
 
+        // Exercise management
+        Route::post('gym/client/program/exercise/add', [GymController::class, 'add_client_exercise']);
+        Route::post('gym/client/program/exercise/edit', [GymController::class, 'edit_client_exercise']);
+        Route::post('gym/client/program/exercise/delete', [GymController::class, 'delete_client_exercise']);
+        Route::post('gym/client/program/exercise/copy', [GymController::class, 'copy_client_exercise']);
+        Route::post('gym/client/program/exercise/days/copy', [GymController::class, 'copy_client_exercise_days']);
+        Route::post('gym/client/program/exercise/days/cut', [GymController::class, 'cut_client_exercise_days']);
+        Route::post('gym/client/program/exercise/days/delete', [GymController::class, 'delete_client_exercise_days']);
+        
+        // Program management
+        Route::post('gym/client/programs/delete', [GymController::class, 'delete_client_program']);
     });
     Route::group(['middleware' => 'CheckCoachIsInGym'], function () {
         Route::post('gym/list/coaches', [GymController::class, 'list_gym_coaches']);

--- a/routes/gym.php
+++ b/routes/gym.php
@@ -51,6 +51,25 @@ Route::middleware(['auth:api', 'CheckSubscription', 'CheckCoachUser'])->group(fu
         
         // Program management
         Route::post('gym/client/programs/delete', [GymController::class, 'delete_client_program']);
+
+        // Template Program management
+        Route::post('gym/programs/list', [GymController::class, 'list_gym_programs']);
+        Route::post('gym/program/add', [GymController::class, 'add_gym_program']);
+        Route::post('gym/program/edit', [GymController::class, 'update_gym_program']);
+        Route::post('gym/program/delete', [GymController::class, 'delete_gym_program']);
+        Route::post('gym/program/update/sync', [GymController::class, 'update_gym_program_sync']);
+        Route::post('gym/program/days/list', [GymController::class, 'list_gym_program_days']);
+
+        // Template Program exercise management
+        Route::post('gym/program/exercises/list', [GymController::class, 'list_gym_program_exercises']);
+        Route::post('gym/program/exercises/by/day/list', [GymController::class, 'list_gym_program_exercises_by_day']);
+        Route::post('gym/program/exercise/add', [GymController::class, 'add_gym_program_exercise']);
+        Route::post('gym/program/exercise/edit', [GymController::class, 'update_gym_program_exercise']);
+        Route::post('gym/program/exercise/delete', [GymController::class, 'delete_gym_program_exercise']);
+        Route::post('gym/program/exercise/copy', [GymController::class, 'copy_gym_program_exercise']);
+        Route::post('gym/program/exercise/days/copy', [GymController::class, 'copy_gym_program_exercise_days']);
+        Route::post('gym/program/exercise/days/cut', [GymController::class, 'cut_gym_program_exercise_days']);
+        Route::post('gym/program/exercise/days/delete', [GymController::class, 'delete_gym_program_exercise_days']);
     });
     Route::group(['middleware' => 'CheckCoachIsInGym'], function () {
         Route::post('gym/list/coaches', [GymController::class, 'list_gym_coaches']);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds many new admin routes and authorization checks around cross-coach access to programs/exercises; mistakes could expose or block data across gyms. Changes also touch payment refund callback behavior and program validation, which could affect billing and program creation flows.
> 
> **Overview**
> Expands the gym admin API to manage *client one-to-one programs* and *template programs* within a gym, adding endpoints to add/edit/delete/copy exercises (including bulk day copy/cut/delete) and to list/update/delete programs and their exercises, with new gym-membership validation checks.
> 
> Updates `ProgramServices::index` to accept an explicit `coach_id` (used by `ProgramController` and the new gym routes) so gym admins can list programs for any coach in their gym. Also includes smaller fixes: refund handling in `ClientServices::checkoutProcessed`, `starting_date` validation loosened to `nullable|required_if`, join-request payload now uses stored email, and new lightweight DB helpers (`gym_coach_exists`, `get_program_coach_id`, `get_exercise_program_id`) to support authorization/validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0ba482f7695f369d72e1540dacc1ed8ddc46e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->